### PR TITLE
Solving issue with products like ABI-L1b-RadF-Repro when trying to bu…

### DIFF
--- a/goes_api/info.py
+++ b/goes_api/info.py
@@ -60,7 +60,18 @@ def get_available_online_product(protocol, satellite):
     list_products = [product[:-1] if product.startswith("ABI") else product for product in list_dirname]
     list_products = np.unique(list_products).tolist()
     # Retrieve sensor, product_level and product list
-    list_sensor_level_product = [product.split("-") for product in list_products]
+    # list_sensor_level_product = [product.split("-") for product in list_products]
+    list_sensor_level_product = []
+    for product in list_products:
+        p = product.split("-")
+        if len(p) == 3:
+            list_sensor_level_product.append(p)
+        elif len(p) == 4:
+            p[2] = p[2] + "-" + p[3]
+            list_sensor_level_product.append(p[0:3])
+        else:
+            pass
+
     # Build a dictionary
     products_dict = {}
     for sensor, product_level, product in list_sensor_level_product:


### PR DESCRIPTION
…ild list_sensor_level_product

# Prework

- [x ] I understand and agree to this repository's [code of conduct](https://github.com/ghiggi/gpm_api/blob/main/CODE_OF_CONDUCT.md).
- [x ] I understand and agree to this repository's [contributing guidelines](https://github.com/ghiggi/gpm_api/blob/main/CONTRIBUTING.md).
- [ x] I have already submitted an [issue](https://github.com/ghiggi/gpm_api/issues) or [discussion thread](https://github.com/ghiggi/gpm_api/discussions) to discuss my idea with the maintainers.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ghiggi/gpm_api/blob/main/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Tutorial
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and communicate accordingly:

**The PR fulfills these requirements:**

- [ ] It's submitted to the branch named as follow:
  - Fix a bug: `bugfix-<some_key>-<word>`
  - Improve the doc: `doc-<some_key>-<word>`
  - Improve a tutorial `tutorial-<some_key>-<word>`
  - Add a new feature: `feature-<some_key>-<word>`
  - Refactor some code: `refactor-<some_key>-<word>`
  - Optimize some code: `optimize-<some_key>-<word>`
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Don't forget to link PR to issue if you are solving one.
- [ ] All tests are passing.
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

# Related GitHub issues and pull requests

- Ref: #

# Summary

Please explain the purpose and scope of your contribution. 
When retrieving sensor, product_level and product list in info.py some products with 4 fields trigger an error downstream. Ie 'ABI-L1b-RadC-Repro', 'ABI-L1b-RadF-Repro' produce an unexpected len 4 list. That tiggers an error when trying to build the products_dict
